### PR TITLE
Add link back to repo from version command

### DIFF
--- a/cleanup.go
+++ b/cleanup.go
@@ -99,7 +99,7 @@ func Version(options *VersionOptions, w io.Writer) error {
 	case options.Quiet:
 		output = fmt.Sprintf("%s\n", version)
 	default:
-		output = fmt.Sprintf("cleanup version %s\n", version)
+		output = fmt.Sprintf("cleanup version %s (%s)\n", version, repoURL)
 	}
 
 	_, _ = w.Write([]byte(output))

--- a/main.go
+++ b/main.go
@@ -11,6 +11,10 @@ import (
 // cleanup binary using the CI/CD pipeline.
 var version string = "UNSPECIFIED"
 
+// repoURL is the "breadcrumb" back to the repo where bug reports or feature
+// requests can be filed or new versions of this tool can be downloaded.
+const repoURL = "https://github.com/dominikbraun/cleanup"
+
 // main builds the CLI commands and executes the desired sub-command.
 func main() {
 	var branchesOptions BranchesOptions


### PR DESCRIPTION
## Changes

Implement breadcrumb URL when using the `version` command.

## Not changed

I'm not familiar enough with Cobra to feel confident implementing the proposed text at the bottom of the help output.

## References

- fixes GH-3